### PR TITLE
add empty string as second arg to base64encode

### DIFF
--- a/lib/DBIx/Class/Fixtures.pm
+++ b/lib/DBIx/Class/Fixtures.pm
@@ -868,7 +868,7 @@ sub dump_object {
 
         $ds{external}->{$field} =
           encode_base64( $class
-           ->backup($key => $args));
+           ->backup($key => $args),'');
       }
     }
 


### PR DESCRIPTION
 to speed up loading of fixtures with external file data.
