### PR TITLE
Switch tests to Test::TempDir::Tiny to enable parallelization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .*.sw?
 \.DS_Store
 .prove
+tmp/

--- a/t/01-new.t
+++ b/t/01-new.t
@@ -2,7 +2,10 @@
 
 use DBIx::Class::Fixtures;
 use Test::More tests => 3;
+use Test::TempDir::Tiny;
 use IO::All;
+
+my $tempdir = tempdir;
 
 my $config_dir = io->catfile(qw't var configs')->name;
 my $imaginary_config_dir = io->catfile(qw't var not_there')->name;

--- a/t/02-dump-basic.t
+++ b/t/02-dump-basic.t
@@ -6,22 +6,25 @@ use lib qw(t/lib);
 use DBICTest;
 use Path::Class;
 use Data::Dumper;
+use Test::TempDir::Tiny;
 use IO::All;
+
+my $tempdir = tempdir;
 
 use if $^O eq 'MSWin32','Devel::Confess';
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema(), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
 
 {
     # do dump
     ok(my $fixtures = DBIx::Class::Fixtures->new({ config_dir => $config_dir, debug => 0 }), 'object created with correct config dir');
-    ok($fixtures->dump({ config => 'simple.json', schema => $schema, directory => io->catfile(qw't var fixtures')->name }), 'simple dump executed okay');
+    ok($fixtures->dump({ config => 'simple.json', schema => $schema, directory => $tempdir }), 'simple dump executed okay');
 
     # check dump is okay
-    my $dir = dir(io->catfile(qw't var fixtures artist')->name);
-    ok(-e io->catfile(qw't var fixtures artist')->name, 'artist directory created');
+    my $dir = dir(io->catfile($tempdir, qw'artist')->name);
+    ok(-e io->catfile($tempdir, qw'artist')->name, 'artist directory created');
 
     my @children = $dir->children;
     is(scalar(@children), 1, 'right number of fixtures created');
@@ -55,13 +58,13 @@ my $config_dir = io->catfile(qw't var configs')->name;
                 "quantity" => 1
             }]
         },
-        schema => $schema, 
-        directory => io->catfile(qw't var fixtures')->name,
+        schema => $schema,
+        directory => $tempdir,
     }), 'simple dump executed okay');
 
     # check dump is okay
-    my $dir = dir(io->catfile(qw't var fixtures artist')->name);
-    ok(-e io->catfile(qw't var fixtures artist')->name, 'artist directory created');
+    my $dir = dir(io->catfile($tempdir, qw'artist')->name);
+    ok(-e io->catfile($tempdir, qw'artist')->name, 'artist directory created');
 
     my @children = $dir->children;
     is(scalar(@children), 1, 'right number of fixtures created');

--- a/t/03-dump-quantity.t
+++ b/t/03-dump-quantity.t
@@ -6,18 +6,21 @@ use lib qw(t/lib);
 use DBICTest;
 use Path::Class;
 use Data::Dumper;
+use Test::TempDir::Tiny;
 use IO::All;
+
+my $tempdir = tempdir;
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema(), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
 
 # do dump
 ok(my $fixtures = DBIx::Class::Fixtures->new({ config_dir => $config_dir, debug => 0 }), 'object created with correct config dir');
-ok($fixtures->dump({ config => 'quantity.json', schema => $schema, directory => io->catfile(qw't var fixtures')->name }), 'quantity dump executed okay');
+ok($fixtures->dump({ config => 'quantity.json', schema => $schema, directory => $tempdir }), 'quantity dump executed okay');
 
 # check dump is okay
-my $dir = dir(io->catfile(qw't var fixtures CD')->name);
+my $dir = dir(io->catfile($tempdir, qw'CD')->name);
 my @children = $dir->children;
 is(scalar(@children), 3, 'right number of cd fixtures created');
 

--- a/t/04-dump-fetch.t
+++ b/t/04-dump-fetch.t
@@ -6,19 +6,22 @@ use lib qw(t/lib);
 use DBICTest;
 use Path::Class;
 use Data::Dumper;
+use Test::TempDir::Tiny;
 use IO::All;
 
+my $tempdir = tempdir;
+
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema(), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
 
 # do dump
 ok(my $fixtures = DBIx::Class::Fixtures->new({ config_dir => $config_dir, debug => 0 }), 'object created with correct config dir');
-ok($fixtures->dump({ config => 'fetch.json', schema => $schema, directory => io->catfile(qw't var fixtures')->name }), 'fetch dump executed okay');
+ok($fixtures->dump({ config => 'fetch.json', schema => $schema, directory => $tempdir }), 'fetch dump executed okay');
 
 # check dump is okay
-my $dir = dir(io->catfile(qw't var fixtures artist')->name);
+my $dir = dir(io->catfile($tempdir, qw'artist')->name);
 my @children = $dir->children;
 is(scalar(@children), 3, 'right number of artist fixtures created');
 
@@ -32,7 +35,7 @@ foreach my $id (1, 2) {
 my $artist1 = $schema->resultset('Artist')->find(1);
 my @artist1_cds = $artist1->cds->all;
 foreach my $cd (@artist1_cds) {
-  my $cd_fix_file = dir(io->catfile(qw't var fixtures')->name, 'CD', $cd->id . '.fix');
+  my $cd_fix_file = dir($tempdir, 'CD', $cd->id . '.fix');
   ok(-e $cd_fix_file, "artist1's cd rel dumped okay");
 }
 
@@ -40,11 +43,11 @@ foreach my $cd (@artist1_cds) {
 my $artist2 = $schema->resultset('Artist')->find(2);
 my @artist2_cds = $artist2->cds->search({ year => { '>' => 2002 } });
 foreach my $cd (@artist2_cds) {
-  my $cd_fix_file = dir(io->catfile(qw't var fixtures')->name, 'CD', $cd->id . '.fix');
+  my $cd_fix_file = dir($tempdir, 'CD', $cd->id . '.fix');
   ok(-e $cd_fix_file, "artist2's cd rel dumped okay");
 }
 
-my $cd_dir = dir(io->catfile(qw't var fixtures CD')->name);
+my $cd_dir = dir(io->catfile($tempdir, qw'CD')->name);
 @children = $cd_dir->children;
 is(scalar(@children), scalar(@artist1_cds) + scalar(@artist2_cds), 'no extra cd fixtures dumped');
 

--- a/t/05-dump-rules.t
+++ b/t/05-dump-rules.t
@@ -6,19 +6,22 @@ use lib qw(t/lib);
 use DBICTest;
 use Path::Class;
 use Data::Dumper;
+use Test::TempDir::Tiny;
 use IO::All;
 
+my $tempdir = tempdir;
+
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema(), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
 
 # do dump
 ok(my $fixtures = DBIx::Class::Fixtures->new({ config_dir => $config_dir, debug => 0 }), 'object created with correct config dir');
-ok($fixtures->dump({ config => 'rules.json', schema => $schema, directory => io->catfile(qw't var fixtures')->name }), 'fetch dump executed okay');
+ok($fixtures->dump({ config => 'rules.json', schema => $schema, directory => $tempdir }), 'fetch dump executed okay');
 
 # check dump is okay
-my $dir = dir(io->catfile(qw't var fixtures')->name);
+my $dir = dir($tempdir);
 my $cd_dir = dir($dir, 'CD');
 my $track_dir = dir($dir, 'track');
 

--- a/t/06-dump-date.t
+++ b/t/06-dump-date.t
@@ -14,14 +14,14 @@ plan skip_all => 'Set $ENV{FIXTURETEST_DSN}, _USER and _PASS to point at MySQL D
 plan tests => 5;
 
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema( dsn => $ENV{FIXTURETEST_DSN}, user => $ENV{FIXTURETEST_USER}, pass => $ENV{FIXTURETEST_PASS}), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir, dsn => $ENV{FIXTURETEST_DSN}, user => $ENV{FIXTURETEST_USER}, pass => $ENV{FIXTURETEST_PASS}), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
 
 # do dump
 ok(my $fixtures = DBIx::Class::Fixtures->new({ config_dir => $config_dir, debug => 0 }), 'object created with correct config dir');
-ok($fixtures->dump({ config => 'date.json', schema => $schema, directory => io->catfile(qw't var fixtures')->name }), 'date dump executed okay');
-ok($fixtures->populate({ ddl => DBICTest->get_ddl_file($schema), connection_details => [$ENV{FIXTURETEST_DSN}, $ENV{FIXTURETEST_USER} || '', $ENV{FIXTURETEST_PASS} || ''], directory => io->catfile(qw't var fixtures')->name }), 'date populate okay');
+ok($fixtures->dump({ config => 'date.json', schema => $schema, directory => $tempdir }), 'date dump executed okay');
+ok($fixtures->populate({ ddl => DBICTest->get_ddl_file($schema), connection_details => [$ENV{FIXTURETEST_DSN}, $ENV{FIXTURETEST_USER} || '', $ENV{FIXTURETEST_PASS} || ''], directory => $tempdir }), 'date populate okay');
 
 my $track = $schema->resultset('Track')->find(9);
 my $now = DateTime->now();

--- a/t/07-dump-all.t
+++ b/t/07-dump-all.t
@@ -6,15 +6,18 @@ use lib qw(t/lib);
 use DBICTest;
 use Path::Class;
 use Data::Dumper; 
+use Test::TempDir::Tiny;
 use IO::All;
+
+my $tempdir = tempdir;
 use if $^O eq 'MSWin32','Devel::Confess';
 plan tests => 16;
 
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema( ), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir, ), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
-my $fixture_dir = io->catfile(qw't var fixtures')->name;
+my $fixture_dir = $tempdir;
 
 # do dump
 {

--- a/t/08-dump-includes.t
+++ b/t/08-dump-includes.t
@@ -6,25 +6,28 @@ use lib qw(t/lib);
 use DBICTest;
 use Path::Class;
 use Data::Dumper; 
+use Test::TempDir::Tiny;
 use IO::All;
 
+my $tempdir = tempdir;
+
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema(), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
 
 # do dump
 ok(my $fixtures = DBIx::Class::Fixtures->new({ config_dir => $config_dir, debug => 0 }), 'object created with correct config dir');
-ok($fixtures->dump({ config => 'includes.json', schema => $schema, directory => io->catfile(qw't var fixtures')->name }), 'simple dump executed okay');
+ok($fixtures->dump({ config => 'includes.json', schema => $schema, directory => $tempdir }), 'simple dump executed okay');
 
 # check dump is okay
-my $producer_dir = dir(io->catfile(qw't var fixtures producer')->name);
+my $producer_dir = dir(io->catfile($tempdir, qw'producer')->name);
 ok(-e $producer_dir, 'producer directory created');
 
 my @producer_children = $producer_dir->children;
 is(scalar(@producer_children), 1, 'right number of fixtures created');
 
-my $artist_dir = dir(io->catfile(qw't var fixtures artist')->name);
+my $artist_dir = dir(io->catfile($tempdir, qw'artist')->name);
 ok(-e $artist_dir, 'artist directory created');
 
 my @artist_children = $artist_dir->children;

--- a/t/09-dump-scalar-ref.t
+++ b/t/09-dump-scalar-ref.t
@@ -6,21 +6,24 @@ use lib qw(t/lib);
 use DBICTest;
 use Path::Class;
 use Data::Dumper; 
+use Test::TempDir::Tiny;
 use IO::All;
 
+my $tempdir = tempdir;
+
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema(), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
 
 # do dump
 ok(my $fixtures = DBIx::Class::Fixtures->new({ config_dir => $config_dir, debug => 0 }), 'object created with correct config dir');
 
-ok($fixtures->dump({ config => 'scalar_ref.json', schema => $schema, directory => io->catfile(qw't var fixtures')->name }), 'simple dump executed okay');
+ok($fixtures->dump({ config => 'scalar_ref.json', schema => $schema, directory => $tempdir }), 'simple dump executed okay');
 
 {
   # check dump is okay
-  my $dir = dir(io->catfile(qw't var fixtures artist')->name);
+  my $dir = dir(io->catfile($tempdir, qw'artist')->name);
   my @children = $dir->children;
   is(scalar(@children), 1, 'right number of fixtures created');
   
@@ -32,7 +35,7 @@ ok($fixtures->dump({ config => 'scalar_ref.json', schema => $schema, directory =
 
 {
   # check dump is okay
-  my $dir = dir(io->catfile(qw't var fixtures CD')->name);
+  my $dir = dir(io->catfile($tempdir, qw'CD')->name);
   my @children = $dir->children;
   is(scalar(@children), 1, 'right number of fixtures created');
   

--- a/t/10-dump-cleanup.t
+++ b/t/10-dump-cleanup.t
@@ -6,23 +6,26 @@ use lib qw(t/lib);
 use DBICTest;
 use Path::Class;
 use Data::Dumper; 
+use Test::TempDir::Tiny;
 use IO::All;
 
+my $tempdir = tempdir;
+
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema(), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
 
 # do dump
 ok(my $fixtures = DBIx::Class::Fixtures->new({ config_dir => $config_dir }), 'object created with correct config dir');
 
-my $output_dir = dir(io->catfile(qw't var fixtures')->name);
+my $output_dir = dir($tempdir);
 $output_dir->mkpath;
 my $file = file($output_dir, 'test_file');
 my $fh = $file->open('w');
 print $fh 'test file';
 $fh->close;
 
-ok($fixtures->dump({ config => 'simple.json', schema => $schema, directory => io->catfile(qw't var fixtures')->name }), 'simple dump executed okay');
+ok($fixtures->dump({ config => 'simple.json', schema => $schema, directory => $tempdir }), 'simple dump executed okay');
 
 ok(-e $file, 'file still exists');

--- a/t/13-populate-two-dbs.t
+++ b/t/13-populate-two-dbs.t
@@ -8,12 +8,15 @@ use Path::Class;
 use Data::Dumper;
 use DBICTest::Schema2;
 use Devel::Confess;
+use Test::TempDir::Tiny;
 use IO::All;
 
+my $tempdir = tempdir;
+
 # set up and populate normal schema
-ok(my $schema = DBICTest->init_schema(), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema');
 my $config_dir = io->catfile(qw't var configs')->name;
-my $dbix_class_different = io->catfile(qw[ t var DBIxClassDifferent.db ])->name;
+my $dbix_class_different = io->catfile($tempdir, qw[ DBIxClassDifferent.db ])->name;
 my @different_connection_details = (
     "dbi:SQLite:$dbix_class_different",
     '', 
@@ -38,24 +41,24 @@ ok(my $fixtures = DBIx::Class::Fixtures->new({
 
 ok($fixtures->dump({ 
       config => "simple.json", 
-      schema => $schema, 
-      directory => io->catfile(qw't var fixtures')->name 
+      schema => $schema,
+      directory => $tempdir 
     }), 
     "simple dump executed okay");
 
 ok($fixtures->populate({ 
       ddl => io->catfile(qw[t lib sqlite_different.sql])->name,
       connection_details => [@different_connection_details], 
-      directory => io->catfile(qw't var fixtures')->name
+      directory => $tempdir
     }),
     'mysql populate okay');
 
 ok($fixtures->populate({ 
       ddl => io->catfile(qw[ t lib sqlite.sql ])->name,
-      connection_details => ['dbi:SQLite:'.io->catfile(qw[ t var DBIxClass.db ])->name, '', ''],
-      directory => io->catfile(qw't var fixtures')->name
+      connection_details => ['dbi:SQLite:'.io->catfile($tempdir, qw[ DBIxClass.db ])->name, '', ''],
+      directory => $tempdir
     }), 
     'sqlite populate okay');
 
-$schema = DBICTest->init_schema(no_deploy => 1);
+$schema = DBICTest->init_schema(db_dir => $tempdir,no_deploy => 1);
 is($schema->resultset('Artist')->count, 1, 'artist imported to sqlite okay');

--- a/t/15-multiple-belongs-to.t
+++ b/t/15-multiple-belongs-to.t
@@ -6,24 +6,27 @@ use lib qw(t/lib);
 use DBICTest;
 use Path::Class;
 use Data::Dumper;
+use Test::TempDir::Tiny;
 use IO::All;
 
+my $tempdir = tempdir;
+
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema(), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
 
 # do dump
 ok(my $fixtures = DBIx::Class::Fixtures->new({ config_dir => $config_dir, debug => 0 }), 'object created with correct config dir');
-ok($fixtures->dump({ config => 'multiple-has-many.json', schema => $schema, directory => io->catfile(qw't var fixtures')->name }), 'fetch dump executed okay');
+ok($fixtures->dump({ config => 'multiple-has-many.json', schema => $schema, directory => $tempdir }), 'fetch dump executed okay');
 
 # check dump is okay
-my $dir = dir(io->catfile(qw't var fixtures')->name);
+my $dir = dir($tempdir);
 
-ok( -e io->catfile(qw't var fixtures producer')->name, "We fetched some producers" );
-ok( -e io->catfile(qw't var fixtures cd_to_producer')->name, "We fetched some cd producer xrefs" );
-ok( -e io->catfile(qw't var fixtures CD')->name, "We fetched some cds" );
-ok( -e io->catfile(qw't var fixtures artist')->name, "We fetched some artists" );
+ok( -e io->catfile($tempdir, qw'producer')->name, "We fetched some producers" );
+ok( -e io->catfile($tempdir, qw'cd_to_producer')->name, "We fetched some cd producer xrefs" );
+ok( -e io->catfile($tempdir, qw'CD')->name, "We fetched some cds" );
+ok( -e io->catfile($tempdir, qw'artist')->name, "We fetched some artists" );
 
 __END__
 while ( my ($dirname, $sourcename) = each %dirs ) {

--- a/t/16-rules-hasmany.t
+++ b/t/16-rules-hasmany.t
@@ -6,16 +6,19 @@ use lib qw(t/lib);
 use DBICTest;
 use Path::Class;
 use Data::Dumper;
+use Test::TempDir::Tiny;
 use IO::All;
 
+my $tempdir = tempdir;
+
 # set up and populate schema
-ok(my $schema = DBICTest->init_schema(), 'got schema');
+ok(my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema');
 
 my $config_dir = io->catfile(qw't var configs')->name;
 
 # do dump
 ok(my $fixtures = DBIx::Class::Fixtures->new({ config_dir => $config_dir, debug => 0 }), 'object created with correct config dir');
-ok($fixtures->dump({ config => 'rules2.json', schema => $schema, directory => io->catfile(qw't var fixtures')->name }), 'quantity dump executed okay');
+ok($fixtures->dump({ config => 'rules2.json', schema => $schema, directory => $tempdir }), 'quantity dump executed okay');
 
 # check dump is okay
 foreach my $test (
@@ -23,7 +26,7 @@ foreach my $test (
   [ 'CD', 2, 'CD', 'cdid' ],
 ) {
   my ($dirname, $count, $moniker, $id) = @$test;
-  my $dir = dir(io->catfile(qw"t var fixtures",$dirname)->name);
+  my $dir = dir(io->catfile($tempdir,$dirname)->name);
   my @children = $dir->children;
   is(scalar(@children), $count, "right number of $dirname fixtures created");
 

--- a/t/17-dump_all_config_sets.t
+++ b/t/17-dump_all_config_sets.t
@@ -6,10 +6,13 @@ use DBICTest;
 use Path::Class;
 use Data::Dumper; 
 use File::Spec;
+use Test::TempDir::Tiny;
 use IO::All;
 
+my $tempdir = tempdir;
+
 ok my $config_dir = io->catfile(qw't var configs')->name;
-ok my $schema = DBICTest->init_schema(), 'got schema';
+ok my $schema = DBICTest->init_schema(db_dir => $tempdir), 'got schema';
 ok my $fixtures = DBIx::Class::Fixtures->new({config_dir => $config_dir}),
   'object created with correct config dir';
   
@@ -19,14 +22,14 @@ my $ret = $fixtures->dump_config_sets({
   schema => $schema,
   directory_template => sub {
       my ($fixture, $params, $set) = @_;
-      File::Spec->catdir('t','var','fixtures','multi', $set);
+      File::Spec->catdir($tempdir,'multi', $set);
   },
 });
 
-ok -e io->catfile(qw't var fixtures multi date.json artist')->name,
+ok -e io->catfile($tempdir, qw'multi date.json artist')->name,
   'artist directory created';
 
-my $dir = dir(io->catfile(qw't var fixtures multi date.json artist')->name);
+my $dir = dir(io->catfile($tempdir, qw'multi date.json artist')->name);
 my @children = $dir->children;
 is(scalar(@children), 1, 'right number of fixtures created');
 

--- a/t/18-extra.t
+++ b/t/18-extra.t
@@ -4,7 +4,10 @@ use File::Path 'rmtree';
 
 use lib qw(t/lib);
 use ExtraTest::Schema;
+use Test::TempDir::Tiny;
 use IO::All;
+
+my $tempdir = tempdir;
 
 (my $schema = ExtraTest::Schema->connect(
   'DBI:SQLite::memory:','',''))->init_schema;
@@ -31,7 +34,7 @@ ok(
   $fixtures->dump({
     config => 'extra.json',
     schema => $schema,
-    directory => io->catfile(qw"t var fixtures photos")->name }),
+    directory => io->catfile($tempdir, qw" photos")->name }),
   'fetch dump executed okay');
 
 ok my $key = $schema->resultset('Photo')->first->file;
@@ -46,7 +49,7 @@ ok(
   $fixtures->populate({
     no_deploy => 1,
     schema => $schema,
-    directory => io->catfile(qw"t var fixtures photos")->name}),
+    directory => io->catfile($tempdir, qw" photos")->name}),
   'populated');
 
 is $key, $schema->resultset('Photo')->first->file,
@@ -58,5 +61,5 @@ done_testing;
 
 END {
     rmtree io->catfile(qw't var files')->name;
-    rmtree io->catfile(qw't var fixtures photos')->name;
+    rmtree io->catfile($tempdir, qw'photos')->name;
 }

--- a/t/lib/DBICTest.pm
+++ b/t/lib/DBICTest.pm
@@ -46,7 +46,11 @@ sub init_schema {
     my $self = shift;
     my %args = @_;
 
-    my $db_file = "t/var/DBIxClass.db";
+    my $db_file
+        = $args{db_dir}
+        ? "$args{db_dir}/DBIxClass.db"
+        : "t/var/DBIxClass.db"
+        ;
 
     mkdir("t/var") unless -d "t/var";
     if ( !$args{no_deploy} ) {


### PR DESCRIPTION
...so we can use different directories for each test, clean them up sensibly,
and run tests in parallel -- successfully.