### PR TITLE
added File::Temp as prerequisite since it is referenced in Fixtures.pm

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -35,6 +35,7 @@ my %WriteMakefileArgs = (
     "DateTime::Format::Pg" => 0,
     "DateTime::Format::SQLite" => "0.1",
     "File::Copy::Recursive" => "0.38",
+    "File::Temp" => "0.2304",
     "Hash::Merge" => "0.1",
     "IO::All" => "0.85",
     "JSON::Syck" => "1.27",

--- a/dist.ini
+++ b/dist.ini
@@ -77,6 +77,7 @@ DateTime::Format::MySQL = 0
 DateTime::Format::Pg = 0
 DateTime::Format::SQLite = 0.1
 File::Copy::Recursive = 0.38
+File::Temp = 0.2304
 Hash::Merge = 0.1
 JSON::Syck = 1.27
 MIME::Base64 = 0


### PR DESCRIPTION
There is the CPANTs warning regarding the metric [prereq matches use](http://cpants.cpanauthors.org/dist/DBIx-Class-Fixtures). I saw that File::Temp is used in Fixtures.pm but not listed as prerequisite in the Makefile so I added it.