### PR TITLE
use quote_identifiers for problematic column names

### DIFF
--- a/lib/DBIx/Class/Fixtures.pm
+++ b/lib/DBIx/Class/Fixtures.pm
@@ -1402,7 +1402,13 @@ sub populate {
              $self->msg("- updating sequence $sequence");
             $rs->result_source->storage->dbh_do(sub {
               my ($storage, $dbh, @cols) = @_;
-              $self->msg(my $sql = "SELECT setval('${sequence}', (SELECT max($column) FROM ${table}));");
+              $self->msg(
+			 my $sql = "SELECT setval('${sequence}', (SELECT max("
+			 .$dbh->quote_identifier($column)
+			 .") FROM "
+			 .$dbh->quote_identifier(${table})
+			 ."));"
+			);
               my $sth = $dbh->prepare($sql);
               my $rv = $sth->execute or die $sth->errstr;
               $self->msg("- $sql");

--- a/lib/DBIx/Class/Fixtures.pm
+++ b/lib/DBIx/Class/Fixtures.pm
@@ -1403,13 +1403,11 @@ sub populate {
             $rs->result_source->storage->dbh_do(sub {
               my ($storage, $dbh, @cols) = @_;
               $self->msg(
-			 my $sql = "SELECT setval('${sequence}', (SELECT max("
-			 .$dbh->quote_identifier($column)
-			 .") FROM "
-			 .$dbh->quote_identifier(${table})
-			 ."));"
-			);
+			 my $sql = sprintf("SELECT setval(?, (SELECT max(%s) FROM %s));",$dbh->quote_identifier($column),$dbh->quote_identifier($table))
+		       );
               my $sth = $dbh->prepare($sql);
+                 $sth->bind_param(1,$sequence);
+
               my $rv = $sth->execute or die $sth->errstr;
               $self->msg("- $sql");
             });


### PR DESCRIPTION
this is a proposed fix for https://rt.cpan.org/Public/Bug/Display.html?id=108017, $dbh->quote_identifiers() should take care of 'bad' column and table names. Unfortunately I don't have a Postgres-Database available so I created just a general testcase at https://gist.github.com/hatorikibble/6b3d937cd447f617f9a0