### PR TITLE
Changes to allow MSWin32 to PASS

### DIFF
--- a/t/12-populate-basic.t
+++ b/t/12-populate-basic.t
@@ -63,6 +63,9 @@ foreach my $set ('simple', 'quantity', 'fetch', 'rules') {
   }
 }
 
+# Force $schema out of scope to disconnect DB so it can be deleted
+$schema = undef if ($^O eq qq{MSWin32});
+
 # use_create => 1
 $schema = DBICTest->init_schema(db_dir => $tempdir);
 $fixtures = DBIx::Class::Fixtures->new({
@@ -75,6 +78,9 @@ ok( $fixtures->dump({
 		directory => $tempdir
 	}), "use_create dump executed okay"
 );
+# Force $schema out of scope to disconnect DB so it can be deleted
+$schema = undef if ($^O eq qq{MSWin32});
+
 $schema = DBICTest->init_schema(db_dir => $tempdir, no_populate => 1 );
 $fixtures->populate({
 	directory => $tempdir,
@@ -83,8 +89,14 @@ $fixtures->populate({
 	no_deploy => 1,
 	use_create => 1
 });
+# Force $schema out of scope to disconnect DB so it can be deleted
+$schema = undef if ($^O eq qq{MSWin32});
+
 $schema = DBICTest->init_schema(db_dir => $tempdir, no_deploy => 1, no_populate => 1 );
 is( $schema->resultset( "Artist" )->find({ artistid => 4 })->name, "Test Name", "use_create => 1 ok" );
+
+# Force $schema out of scope to disconnect DB so it can be deleted
+$schema = undef if ($^O eq qq{MSWin32});
 
 $schema = DBICTest->init_schema(db_dir => $tempdir, no_populate => 1 );
 $fixtures->populate({

--- a/t/compile.t
+++ b/t/compile.t
@@ -4,8 +4,10 @@ use Test::Compile::Internal;
 use Test::More;
 use Module::Runtime qw[ use_module ];
 use FindBin;
-use lib "$FindBin::Bin/../lib";
-use lib "$FindBin::Bin/../SocialFlow-Web-Config/lib";
+use File::Spec;
+use File::Basename qw(dirname basename);
+use lib File::Spec->catdir(File::Spec->splitdir(dirname(__FILE__)), qw(.. lib));
+use lib File::Spec->catdir(File::Spec->splitdir(dirname(__FILE__)), qw(.. SocialFlow-Web-Config lib));
 
 BEGIN {
     use FindBin;
@@ -17,8 +19,8 @@ my @pms = Test::Compile::Internal->all_pm_files("lib");
 plan tests => 0+@pms;
 
 for my $pm (@pms) {
-    $pm =~ s!(^lib/|\.pm$)!!g;
-    $pm =~ s|/|::|g;
+    $pm = join(qq{::}, File::Spec->splitdir(dirname($pm)), basename($pm));
+    $pm =~ s!(^lib::|\.pm$)!!g;
     ok use_module($pm),$pm;
     $pm->import;
 }


### PR DESCRIPTION
First and foremost, to work on Windows, IO::All must be patched [see IO::All Pull Request #81](https://github.com/ingydotnet/io-all-pm/pull/81)

After patching my IO::All, I still encountered errors on Windows. To correct those errors, I made the following changes:
* In t/12-populate-basic.t, DBICTest could not delete the database unless you disconnected first.
  * Forcing the $schema variable out of scope causes the disconnect, allowing the database to be deleted.
* In t/compile.t, failed on Windows because regex assumed Linux path separator / but on Windows the path separator is \.
  * Using File::Spec and File::Basename makes tests OS independent.