### PR TITLE
Added failing tests for `external`, fix for tests

### DIFF
--- a/lib/DBIx/Class/Fixtures.pm
+++ b/lib/DBIx/Class/Fixtures.pm
@@ -644,7 +644,7 @@ sub dump {
   $tmp_output_dir->file('_config_set')->print( Dumper $config );
 
   $config->{rules} ||= {};
-  my @sources = sort { $a->{class} cmp $b->{class} } @{delete $config->{sets}};
+  my @sources = @{delete $config->{sets}};
 
   while ( my ($k,$v) = each %{ $config->{rules} } ) {
     if ( my $source = eval { $schema->source($k) } ) {

--- a/lib/DBIx/Class/Fixtures.pm
+++ b/lib/DBIx/Class/Fixtures.pm
@@ -867,8 +867,8 @@ sub dump_object {
 
     # mess with dates if specified
     if ($set->{datetime_relative}) {
-      my $formatter= $object->result_source->schema->storage->datetime_parser;
-      unless ($@ || !$formatter) {
+      my $formatter= eval {$object->result_source->schema->storage->datetime_parser};
+      unless (!$formatter) {
         my $dt;
         if ($set->{datetime_relative} eq 'today') {
           $dt = DateTime->today;

--- a/t/18-extra.t
+++ b/t/18-extra.t
@@ -18,7 +18,8 @@ open(my $fh, '<', io->catfile(qw't 18-extra.t')->name) ||
 ok my $row = $schema
   ->resultset('Photo')
   ->create({
-    photographer=>'john',
+    album=> {name=>'masterpiece'},
+    photographer=> {name=>'john'},
     file=>$fh,
   });
 
@@ -42,6 +43,8 @@ ok my $key = $schema->resultset('Photo')->first->file;
 ok -e $key, 'File Created';
 
 ok $schema->resultset('Photo')->delete;
+ok $schema->resultset('Photographer')->delete;
+ok $schema->resultset('Album')->delete;
 
 ok ! -e $key, 'File Deleted';
 

--- a/t/lib/ExtraTest/Schema.pm
+++ b/t/lib/ExtraTest/Schema.pm
@@ -1,3 +1,52 @@
+package ExtraTest::Schema::Result::Album;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->table('album');
+__PACKAGE__->add_columns(
+  'albumid' => {
+    data_type => 'integer',
+    is_auto_increment => 1,
+  },
+  'name' => {
+    data_type => 'varchar',
+    size      => 100,
+    is_nullable => 1,
+  },
+);
+__PACKAGE__->set_primary_key('albumid');
+
+__PACKAGE__->has_many(
+    photos => 'ExtraTest::Schema::Result::Photo'
+);
+
+1;
+
+package ExtraTest::Schema::Result::Photographer;
+
+use base 'DBIx::Class::Core';
+
+__PACKAGE__->table('photographer');
+__PACKAGE__->add_columns(
+  'photographerid' => {
+    data_type => 'integer',
+    is_auto_increment => 1,
+  },
+  'name' => {
+    data_type => 'varchar',
+    size      => 100,
+    is_nullable => 1,
+  },
+);
+__PACKAGE__->set_primary_key('photographerid');
+
+__PACKAGE__->has_many(
+    photos => 'ExtraTest::Schema::Result::Photo'
+);
+
+1;
+
+
 package ExtraTest::Schema::Result::Photo;
 
 use strict;
@@ -13,9 +62,11 @@ __PACKAGE__->add_columns(
 	data_type => 'integer',
 	is_auto_increment => 1,
   },
+  album => {
+    data_type => 'integer',
+  },
   photographer => {
-    data_type => 'varchar',
-    size => 40,
+    data_type => 'integer',
   },
   file => {
 	data_type => 'varchar',
@@ -26,6 +77,9 @@ __PACKAGE__->add_columns(
 
 __PACKAGE__->set_primary_key('photo_id');
 
+__PACKAGE__->belongs_to( photographer => 'ExtraTest::Schema::Result::Photographer' );
+__PACKAGE__->belongs_to( album => 'ExtraTest::Schema::Result::Album' );
+
 package ExtraTest::Schema;
 
 use strict;
@@ -33,6 +87,10 @@ use warnings;
 
 use base 'DBIx::Class::Schema';
 
+__PACKAGE__->register_class(
+  Album => 'ExtraTest::Schema::Result::Album');
+__PACKAGE__->register_class(
+  Photographer => 'ExtraTest::Schema::Result::Photographer');
 __PACKAGE__->register_class(
   Photo => 'ExtraTest::Schema::Result::Photo');
 
@@ -53,9 +111,18 @@ sub init_schema {
 1;
 
 __DATA__
+CREATE TABLE album (
+  albumid INTEGER PRIMARY KEY NOT NULL,
+  name varchar(100) NOT NULL
+);
+CREATE TABLE photographer (
+  photographerid INTEGER PRIMARY KEY NOT NULL,
+  name varchar(100) NOT NULL
+);
 CREATE TABLE photo (
   photo_id INTEGER PRIMARY KEY NOT NULL,
-  photographer varchar(40) NOT NULL,
+  album INTEGER NOT NULL,
+  photographer INTEGER NOT NULL,
   file varchar(255) NOT NULL
 )
 

--- a/t/var/configs/extra.json
+++ b/t/var/configs/extra.json
@@ -8,5 +8,17 @@
                 "args": {"path":"__ATTR(photo_dir)__"}
             }
         }
+	},{
+		"class": "Album",
+		"quantity": "all",
+         "fetch" : [
+            {
+               "quantity" : "all",
+               "rel" : "photos"
+            }
+         ]
+	},{
+		"class": "Photographer",
+		"quantity": "all"
 	}]
 }


### PR DESCRIPTION
If config uses has_many to dump a set, the set’s config is not used, so attrs such as `external` are not honoured. Even using `rules` does not solve the problem. Using unsorted `sets` array to specify dump order solves the problem.

Using extra.json from this commit as an example. The 'Album' set is configured to fetch all has_many photos. When sets are sorted as part of `dump`, then the 'Album' set is dumped before the 'Photo' set, and the `external` attribute is not included. 

Putting 'Photo' first in the `sets` array should fix that dependancy, but doesn't if sets are sorted by class name. This patch removes the sorting of sets, and dumps them in the order defined in the config. 

The revised test files in this commit fail without the change to Fixtures.pm. 

Whether the fix of 'not sorting' is correct solution is debatable. I believe that array order in config should be honoured, and not sorted by class name. 
