### PR TITLE
use Config::Any::YAML for free yaml support

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -81,6 +81,7 @@ File::Copy::Recursive = 0.38
 File::Temp = 0.2304
 Hash::Merge = 0.1
 JSON::Syck = 1.27
+YAML::XS   = 0
 MIME::Base64 = 0
 Path::Class = 0.32
 Scalar::Util = 1.27

--- a/lib/DBIx/Class/Fixtures.pm
+++ b/lib/DBIx/Class/Fixtures.pm
@@ -6,7 +6,7 @@ use warnings;
 use DBIx::Class 0.08100;
 use DBIx::Class::Exception;
 use Class::Accessor::Grouped;
-use Config::Any::JSON;
+use Config::Any::YAML;
 use Data::Dump::Streamer;
 use Data::Visitor::Callback;
 use Hash::Merge qw( merge );
@@ -738,7 +738,7 @@ sub load_config_file {
   DBIx::Class::Exception->throw("config does not exist at $config_file")
     unless -e "$config_file";
 
-  my $config = Config::Any::JSON->load($config_file);
+  my $config = Config::Any::YAML->load($config_file);
 
   #process includes
   if (my $incs = $config->{includes}) {
@@ -757,7 +757,7 @@ sub load_config_file {
       DBIx::Class::Exception->throw("config does not exist at $include_file")
         unless -e "$include_file";
 
-      my $include = Config::Any::JSON->load($include_file);
+      my $include = Config::Any::YAML->load($include_file);
       $self->msg($include);
       $config = merge( $config, $include );
     }


### PR DESCRIPTION
Since JSON is a subset of YAML, wouldn't it make sense to use Config::Any::YAML instead of ::JSON? YAML is orders of magnitude easier to write, and this won't break backcompat at all.

To be fair, I haven't tested this out with all the YAML backend, and haven't yet required one in the dist.ini.